### PR TITLE
Add default link when styling option is missing

### DIFF
--- a/src/main/java/com/floppylab/markdown2document/domain/Link.java
+++ b/src/main/java/com/floppylab/markdown2document/domain/Link.java
@@ -6,6 +6,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 public class Link extends Input {
+  
+    public static final Link DEFAULT = new Link("https://floppylab.com/resources/markdown2document/sample.css");
 
     public Link(String link) {
         this.content = link;

--- a/src/main/java/com/floppylab/markdown2document/util/CommandLineTool.java
+++ b/src/main/java/com/floppylab/markdown2document/util/CommandLineTool.java
@@ -19,7 +19,7 @@ import org.apache.commons.cli.ParseException;
 
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 
 @Log
@@ -120,7 +120,7 @@ public class CommandLineTool {
             if (cmd.hasOption("mp")) {
                 String[] markdownPathsValue = cmd.getOptionValue("mp").split(",");
                 for (String path : markdownPathsValue) {
-                    document.getMarkdownContents().add(new Content(Path.of(path)));
+                    document.getMarkdownContents().add(new Content(Paths.get(path)));
                 }
             }
 
@@ -142,7 +142,7 @@ public class CommandLineTool {
             if (cmd.hasOption("sp")) {
                 String[] stylePathsValue = cmd.getOptionValue("sp").split(",");
                 for (String path : stylePathsValue) {
-                    document.getStyles().add(new Content(Path.of(path)));
+                    document.getStyles().add(new Content(Paths.get(path)));
                 }
             }
 

--- a/src/main/java/com/floppylab/markdown2document/util/CommandLineTool.java
+++ b/src/main/java/com/floppylab/markdown2document/util/CommandLineTool.java
@@ -177,6 +177,9 @@ public class CommandLineTool {
             // processing
             log.info(document.toString());
             if (documentGenerator != null) {
+                if (document.getStyles().isEmpty()) {
+                    document.getStyles().add(Link.DEFAULT);
+                }
                 Output output = documentGenerator.generate(document);
                 if (fileName != null) {
                     output.toFile(fileName);


### PR DESCRIPTION
Where should `base.css` be placed? 
In `resource` directory? Or external link? Or maybe set by a configuration file?
I just used [sample.css](https://floppylab.com/resources/markdown2document/sample.css).

#10 #17 

**NOTE**: I tried to add an unit test for my commit. But the main flow is all cramped in `CommandLineTool.processCommandLineArgs` so I cannot find a way to write test cases. (It would be overwhelming if we try to parse the created pdf or html and see if the styles are applied, right?)
I suggest to return `document` or `documentGenerator` in `processCommandLineArgs`.
Or you better split this function into multiple functions that do small tasks, such as getting options, parsing line args and building a document.
#12 