### PR TITLE
Add nbactions.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dependency-reduced-pom.xml
 *.njsproj
 *.sln
 sample.*
+/nbactions.xml


### PR DESCRIPTION
`nbactions.xml` is automatically created by NetBeans.

Since `nbactions.xml` is not included in gitignore, future contributors will be confused.